### PR TITLE
Handle stdout and stderr as {ok, _} and {error, _}

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,12 @@ forward it to a spawned process.  When the C port sees a null byte
 closes stdin and sends stdout from the spawned process to normal stdout.
 
 Erlang ports are also unable to differentiate between stdout and stderr.
-If the spawned process writes to stderr instead of stdout, the C port prepends
-the return data with the ASCII/UTF-8 PU1 byte (0x91). When stdinout sees this
-byte as a first byte, it will remove it and return the data as {error, Data}
-instead of {ok, Data}.
+Therefore, the C port prepends the output from the spawned process with a status
+byte. When stdinout sees this byte as a first byte, it will remove it and return
+the stdout data as {ok, Data}, or the stderr data as {error, Data}.
 
 Note: Your input must not contain null bytes or else your input will terminate
-on them. Nor can your output start with the PU1 byte (0x91) as it will be removed
-from the stream and signal as error.
+on them. But there are no restrictions on the output, it can be any binary stream.
 
 API
 ---

--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ forward it to a spawned process.  When the C port sees a null byte
 (automatically appended to your input when you call `stdinout:send/2`), it
 closes stdin and sends stdout from the spawned process to normal stdout.
 
-Note: your input must not contain null bytes or else your input will terminate
-on them.
+Erlang ports are also unable to differentiate between stdout and stderr.
+If the spawned process writes to stderr instead of stdout, the C port prepends
+the return data with the ASCII/UTF-8 PU1 byte (0x91). When stdinout sees this
+byte as a first byte, it will remove it and return the data as {error, Data}
+instead of {ok, Data}.
+
+Note: Your input must not contain null bytes or else your input will terminate
+on them. Nor can your output start with the PU1 byte (0x91) as it will be removed
+from the stream and signal as error.
 
 API
 ---

--- a/c_src/errcat.c
+++ b/c_src/errcat.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+
+int is_open(int fd) {
+    errno = 0;
+    fcntl(fd, F_GETFD);
+    return errno != EBADF;
+}
+
+int main(int argc, char **argv) {
+    char buf[BUFSIZ];
+    ssize_t count;
+
+    do { count = read(STDIN_FILENO, buf, BUFSIZ); }
+    while ( count == -1 && errno == EINTR );
+
+    if (count == -1) {
+        perror("read");
+        exit(1);
+    }
+
+    do {
+      buf[count] = 0;
+      fputs(buf, stderr);
+      count = read(STDIN_FILENO, buf, BUFSIZ);
+    }
+    while (count > 0 && is_open(STDIN_FILENO));
+
+    exit(0);
+}

--- a/c_src/stdin_forcer.c
+++ b/c_src/stdin_forcer.c
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <errno.h>
-#include <fcntl.h>
 
 #define PARENT_READ readpipe[0]
 #define CHILD_WRITE readpipe[1]
@@ -16,20 +15,16 @@
 #define PARENT_ERROR errorpipe[0]
 #define CHILD_ERROR errorpipe[1]
 
-const unsigned char PU1 = 145;  /* ASCII & UTF-8 control character: 145 | 0x91 | PU1 | Reserved for private use. */
+/* Status bytes */
+const unsigned char SUCCES_BYTE = 145;  /* ASCII & UTF-8 control character: 145 | 0x91 | PU1 | Reserved for private use. */
+const unsigned char ERROR_BYTE  = 146;  /* ASCII & UTF-8 control character: 146 | 0x92 | PU2 | Reserved for private use. */
 
 int dup2close(int oldfd, int newfd) {
   while ((dup2(oldfd, newfd) == -1) && (errno == EINTR)) {}
   return close(oldfd);
 }
 
-int is_open(int fd) {
-    errno = 0;
-    fcntl(fd, F_GETFD);
-    return errno != EBADF;
-}
-
-void toSTDOUT(int fd, const char *firstByte) {
+void toSTDOUT(int fd, const char firstByte) {
   char buf[BUFSIZ];
   ssize_t count;
 
@@ -40,15 +35,16 @@ void toSTDOUT(int fd, const char *firstByte) {
       perror("read");
       exit(1);
   }
+  else if (count > 0) {
+    if (firstByte)
+      write(STDOUT_FILENO, &firstByte, 1); /* Write first byte */
 
-  if (firstByte && count > 0)
-    write(STDOUT_FILENO, firstByte, 1); /* Write first byte */
-
-  do {
-    write(STDOUT_FILENO, buf, count); /* Vomit forth our output on STDOUT */
-    count = read(fd, buf, BUFSIZ);
+    do {
+      write(STDOUT_FILENO, buf, count); /* Vomit forth our output on STDOUT */
+      count = read(fd, buf, BUFSIZ);
+    }
+    while (count > 0);
   }
-  while (count > 0 && is_open(fd));
 }
 
 int main(int argc, char *argv[]) {
@@ -84,13 +80,13 @@ int main(int argc, char *argv[]) {
 
         close(PARENT_READ); /* We aren't the parent. Decrement fd refcounts. */
         close(PARENT_WRITE);
-	close(PARENT_ERROR);
+        close(PARENT_ERROR);
 
         /* CHILD_READ  = STDIN  to the exec'd process.
            CHILD_WRITE = STDOUT to the exec'd process.
            CHILD_ERROR = STDERR to the exec'd process. */
-        if (!dup2close(CHILD_READ, STDIN_FILENO) &&
-            dup2close(CHILD_WRITE, STDOUT_FILENO) &&
+        if (dup2close(CHILD_READ, STDIN_FILENO) ||
+            dup2close(CHILD_WRITE, STDOUT_FILENO) ||
 	    dup2close(CHILD_ERROR, STDERR_FILENO)) {
             perror("dup2 or close");
             _exit(EXIT_FAILURE);
@@ -103,23 +99,24 @@ int main(int argc, char *argv[]) {
         _exit(EXIT_FAILURE); /* Silence a warning */
     } else {
         /* Original Parent Process */
-	char buf;
+        char buf;
 
         close(CHILD_READ); /* We aren't the child.  Close its read/write. */
         close(CHILD_WRITE);
-	close(CHILD_ERROR);
-        /* We should catch the child's exit signal if it dies before we send
-         * STDIN*/
+        close(CHILD_ERROR);
+
+        /* Read until 0 byte */
         while (read(STDIN_FILENO, &buf, 1) > 0 && buf != 0x0) {
             unused = write(PARENT_WRITE, &buf, 1);
         }
         close(PARENT_WRITE); /* closing PARENT_WRITE sends EOF to CHILD_READ */
 
-	toSTDOUT(PARENT_READ, 0);
-	toSTDOUT(PARENT_ERROR, (char*)&PU1);
+        toSTDOUT(PARENT_READ, (char)SUCCES_BYTE);
+        toSTDOUT(PARENT_ERROR, (char)ERROR_BYTE);
 
-	close(PARENT_READ); /* done reading from writepipe */
-	close(PARENT_ERROR); /* done reading from errorpipe */
+        close(PARENT_READ);   /* done reading from writepipe */
+        close(PARENT_ERROR);  /* done reading from errorpipe */
+        close(STDOUT_FILENO); /* done writing to stdout */
 
         wait(NULL);          /* Wait for child to exit */
 

--- a/c_src/stdin_forcer.c
+++ b/c_src/stdin_forcer.c
@@ -6,13 +6,18 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdint.h>
+#include <errno.h>
 
 #define PARENT_READ     readpipe[0]
 #define CHILD_WRITE     readpipe[1]
 #define CHILD_READ      writepipe[0]
 #define PARENT_WRITE    writepipe[1]
 
-#define DUP2CLOSE(oldfd, newfd) (dup2(oldfd, newfd) == 0 && close(oldfd) == 0)
+int dup2close(int oldfd, int newfd)
+{
+  while ((dup2(oldfd, newfd) == -1) && (errno == EINTR)) {}
+  return close(oldfd);
+}
 
 int main(int argc, char *argv[]) {
   int readpipe[2], writepipe[2];
@@ -34,21 +39,21 @@ int main(int argc, char *argv[]) {
     char *cmd = argv[1];
     char *exec_args[64] = {0};
     int i;
-  
+
     for (i = 0; i < argc - 1; i++) {
       /* args to stdin_forcer are the program and optional args to exec.
          Here we copy pointers pointing to strings of cmd/args.
          exec_args is indexed one lower than argv. */
       exec_args[i] = argv[i+1];
     }
-    
+
     close(PARENT_READ);  /* We aren't the parent. Decrement fd refcounts. */
     close(PARENT_WRITE);
 
     /* CHILD_READ  = STDIN  to the exec'd process.
        CHILD_WRITE = STDOUT to the exec'd process. */
-    if (!DUP2CLOSE(CHILD_READ,   STDIN_FILENO) &&
-         DUP2CLOSE(CHILD_WRITE, STDOUT_FILENO)) {
+    if (!dup2close(CHILD_READ,   STDIN_FILENO) &&
+         dup2close(CHILD_WRITE, STDOUT_FILENO)) {
       perror("dup2 or close");
       _exit(EXIT_FAILURE);
     }

--- a/c_src/stdin_forcer.c
+++ b/c_src/stdin_forcer.c
@@ -7,26 +7,58 @@
 #include <string.h>
 #include <stdint.h>
 #include <errno.h>
+#include <fcntl.h>
 
 #define PARENT_READ readpipe[0]
 #define CHILD_WRITE readpipe[1]
 #define CHILD_READ writepipe[0]
 #define PARENT_WRITE writepipe[1]
+#define PARENT_ERROR errorpipe[0]
+#define CHILD_ERROR errorpipe[1]
 
-int dup2close(int oldfd, int newfd)
-{
+const unsigned char PU1 = 145;  /* ASCII & UTF-8 control character: 145 | 0x91 | PU1 | Reserved for private use. */
+
+int dup2close(int oldfd, int newfd) {
   while ((dup2(oldfd, newfd) == -1) && (errno == EINTR)) {}
   return close(oldfd);
 }
 
+int is_open(int fd) {
+    errno = 0;
+    fcntl(fd, F_GETFD);
+    return errno != EBADF;
+}
+
+void toSTDOUT(int fd, const char *firstByte) {
+  char buf[BUFSIZ];
+  ssize_t count;
+
+  do { count = read(fd, buf, BUFSIZ); }
+  while ( count == -1 && errno == EINTR );
+
+  if (count == -1) {
+      perror("read");
+      exit(1);
+  }
+
+  if (firstByte && count > 0)
+    write(STDOUT_FILENO, firstByte, 1); /* Write first byte */
+
+  do {
+    write(STDOUT_FILENO, buf, count); /* Vomit forth our output on STDOUT */
+    count = read(fd, buf, BUFSIZ);
+  }
+  while (count > 0 && is_open(fd));
+}
+
 int main(int argc, char *argv[]) {
-    int readpipe[2], writepipe[2];
+    int readpipe[2], writepipe[2], errorpipe[2];
     int unused __attribute__((unused));
     pid_t cpid;
 
     assert(1 < argc && argc < 64);
 
-    if (pipe(readpipe) == -1 || pipe(writepipe) == -1) {
+    if (pipe(readpipe) == -1 || pipe(writepipe) == -1 || pipe(errorpipe) == -1) {
         perror("pipe");
         exit(EXIT_FAILURE);
     }
@@ -52,11 +84,14 @@ int main(int argc, char *argv[]) {
 
         close(PARENT_READ); /* We aren't the parent. Decrement fd refcounts. */
         close(PARENT_WRITE);
+	close(PARENT_ERROR);
 
         /* CHILD_READ  = STDIN  to the exec'd process.
-           CHILD_WRITE = STDOUT to the exec'd process. */
+           CHILD_WRITE = STDOUT to the exec'd process.
+           CHILD_ERROR = STDERR to the exec'd process. */
         if (!dup2close(CHILD_READ, STDIN_FILENO) &&
-            dup2close(CHILD_WRITE, STDOUT_FILENO)) {
+            dup2close(CHILD_WRITE, STDOUT_FILENO) &&
+	    dup2close(CHILD_ERROR, STDERR_FILENO)) {
             perror("dup2 or close");
             _exit(EXIT_FAILURE);
         }
@@ -68,22 +103,26 @@ int main(int argc, char *argv[]) {
         _exit(EXIT_FAILURE); /* Silence a warning */
     } else {
         /* Original Parent Process */
-        char buf;
+	char buf;
 
         close(CHILD_READ); /* We aren't the child.  Close its read/write. */
         close(CHILD_WRITE);
+	close(CHILD_ERROR);
         /* We should catch the child's exit signal if it dies before we send
          * STDIN*/
         while (read(STDIN_FILENO, &buf, 1) > 0 && buf != 0x0) {
             unused = write(PARENT_WRITE, &buf, 1);
         }
         close(PARENT_WRITE); /* closing PARENT_WRITE sends EOF to CHILD_READ */
+
+	toSTDOUT(PARENT_READ, 0);
+	toSTDOUT(PARENT_ERROR, (char*)&PU1);
+
+	close(PARENT_READ); /* done reading from writepipe */
+	close(PARENT_ERROR); /* done reading from errorpipe */
+
         wait(NULL);          /* Wait for child to exit */
-        while (read(PARENT_READ, &buf, 1) > 0) {
-            unused = write(STDOUT_FILENO, &buf,
-                           1); /* Vomit forth our output on STDOUT */
-        }
-        close(PARENT_READ); /* done reading from writepipe */
+
         exit(EXIT_SUCCESS); /* This was a triumph */
     }
 }

--- a/rebar.config
+++ b/rebar.config
@@ -1,9 +1,7 @@
-{post_hooks,
- [{clean, "rm -f priv/stdin_forcer"},
-  {compile, "$CC -Wall -Werror -ansi -pedantic -Os "
-            "c_src/stdin_forcer.c -o priv/stdin_forcer"}]}.
-
 {deps, [
         {oneshot, "1.7.0",
           {git, "https://github.com/mattsta/oneshot.git", {tag, "v1.7.0"}}}
        ]}.
+
+{port_specs, [{"priv/stdin_forcer",     ["c_src/stdin_forcer.c"]},
+              {"priv/errcat",           ["c_src/errcat.c"]}]}.

--- a/src/stdinout.erl
+++ b/src/stdinout.erl
@@ -38,14 +38,14 @@ send_raw(Server, Content) ->
 %% stdin->stdout through pool or network
 %%====================================================================
 send({Host, Port}, Content) ->
-  check_err(send(Host, Port, Content));
+  check_err(iolist_to_binary(send(Host, Port, Content)));
 send(Server, Content) ->
-  check_err(send_raw(Server, Content)).
+  check_err(iolist_to_binary(send_raw(Server, Content))).
 
-check_err([<<145, Tail/binary>>]) -> {ok, [<<Tail/binary>>]};    % stdin_forcer SUCCES_BYTE
-check_err([<<146, Tail/binary>>]) -> {error, [<<Tail/binary>>]}; % stdin_forcer ERROR_BYTE
-check_err([])                     -> {ok, []};                   % empty response
-check_err(Data)                   -> {invalid_error_byte, Data}.
+check_err(<<145, Tail/binary>>) -> {ok, <<Tail/binary>>};    % stdin_forcer SUCCES_BYTE
+check_err(<<146, Tail/binary>>) -> {error, <<Tail/binary>>}; % stdin_forcer ERROR_BYTE
+check_err(<<>>)                 -> {ok, <<>>};                   % empty response
+check_err(Data)                 -> {invalid_error_byte, Data}.
 
 %%====================================================================
 %% stdin->stdout through network

--- a/src/stdinout_pool_server.erl
+++ b/src/stdinout_pool_server.erl
@@ -178,7 +178,7 @@ initial_setup(#state{count = Count} = State) ->
 setup(#state{cmd = Cmd, forcer = Forcer}) ->
 %  io:format("Opening ~s~n", [Cmd]),  % Uncomment to see re-spawns happen live
   open_port({spawn_executable, Forcer},
-             [stream, use_stdio, stderr_to_stdout, binary, eof,
+             [stream, use_stdio, binary, eof,
               {args, string:tokens(Cmd, " ")}]).
 
 get_base_dir(Module) ->

--- a/test/stdinout_tests.erl
+++ b/test/stdinout_tests.erl
@@ -3,7 +3,7 @@
 
 -define(E(A, B), ?assertEqual(A, B)).
 -define(_E(A, B), ?_assertEqual(A, B)).
--define(B(X), iolist_to_binary(validate(X))).
+
 
 get_base_dir(Module) ->
   {file, Here} = code:is_loaded(Module),
@@ -12,29 +12,32 @@ get_base_dir(Module) ->
 add_oneshot_dep() ->
   code:add_path(get_base_dir(?MODULE) ++ "deps/oneshot/ebin").
 
-validate({ok, Data}) ->
-  Data.
-
 setup_ports() ->
   add_oneshot_dep(),
 
+  Echoerr = get_base_dir(?MODULE) ++ "/priv/errcat",
+
   % Obviously this test only works if you have /bin/cat and /usr/bin/wc
-  S1 = stdinout:start_link(cat1, "/bin/cat"),
-  S2 = stdinout:start_link(cat2, "/bin/cat"),
-  S3 = stdinout:start_link(cat3, "/bin/cat"),
-  S4 = stdinout:start_link(cat4, "/bin/cat"),
-  S5 = stdinout:start_link(wc,   "/usr/bin/wc"),
+  CAT1 = stdinout:start_link(cat1, "/bin/cat"),
+  CAT2 = stdinout:start_link(cat2, "/bin/cat"),
+  CAT3 = stdinout:start_link(cat3, "/bin/cat"),
+  CAT4 = stdinout:start_link(cat4, "/bin/cat"),
+  WC1  = stdinout:start_link(wc,   "/usr/bin/wc"),
 
-  S6 = stdinout:start_link(catn1, "/bin/cat",    "127.0.0.1", 6651),
-  S7 = stdinout:start_link(catn2, "/bin/cat",    "127.0.0.1", 6652),
-  S8 = stdinout:start_link(wcn,   "/usr/bin/wc", "127.0.0.1", 6653),
+  CAT6 = stdinout:start_link(catn1, "/bin/cat",    "127.0.0.1", 6651),
+  CAT7 = stdinout:start_link(catn2, "/bin/cat",    "127.0.0.1", 6652),
+  WC2  = stdinout:start_link(wcn,   "/usr/bin/wc", "127.0.0.1", 6653),
 
-  [unlink(P) || {ok, P} <- [S1, S2, S3, S4, S5, S6, S7, S8]],
-  [P || {ok, P} <- [S1, S2, S3, S4, S5, S6, S7, S8]].
+  ERR1 = stdinout:start_link(errcat,            Echoerr),
+  ERR2 = stdinout:start_link(errcat_net,        Echoerr, "127.0.0.1", 6654),
+
+  [unlink(P) || {ok, P} <- [CAT1, CAT2, CAT3, CAT4, WC1, CAT6, CAT7, WC2, ERR1, ERR2]],
+  [P || {ok, P} <- [CAT1, CAT2, CAT3, CAT4, WC1, CAT6, CAT7, WC2, ERR1, ERR2]].
 
 cleanup_ports(Ps) ->
   [stdinout:shutdown(P) || P <- Ps].
 
+% Test responses on STDOUT
 everything_erlang_API_in_parallel_test_() ->
   {setup,
     fun setup_ports/0,
@@ -42,29 +45,53 @@ everything_erlang_API_in_parallel_test_() ->
     fun(_) ->
       {inparallel,
         [
-          ?_E(<<"hello">>, ?B(stdinout:send(cat1, "hello"))),
-          ?_E(<<"hello">>, ?B(stdinout:send(cat1, <<"hello">>))),
-          ?_E(<<"hello">>, ?B(stdinout:send(cat1, [<<"hello">>]))),
-          ?_E(<<"hello">>, ?B(stdinout:send(cat1, [<<"he">>, <<"llo">>]))),
-          ?_E(ok, stdinout:reload(cat1)),
-          ?_E(<<"hello">>, ?B(stdinout:send(cat1, ["he", "llo"]))),
-          ?_E(<<>>, ?B(stdinout:send(cat1, ""))),
-          ?_E(ok, stdinout:reload(cat2)),
-          ?_E(<<"hello">>, ?B(stdinout:pipe("hello",[cat1, cat2, cat3, cat4]))),
-          ?_E({error, cat1, <<"hello">>},
-            % this wacky fun exists to erlang:iolist_to_binary/1 the ErrorIoList
-            fun() ->
-              {error, cat1, ErrorIoList} =
-                stdinout:pipe("hello", [{cat1, "he"}, cat2, cat3, cat4]),
-              {error, cat1, iolist_to_binary(ErrorIoList)}
-            end()),
-         ?_E(ok, stdinout:reload(cat1)),
-          ?_E({error, wc, <<"      0       1       5\n">>},
-            fun() ->
-              {error, wc, ErrorIoList} =
-                stdinout:pipe("hello", [{cat1, "bob"}, {wc, "5"}, cat3, cat4]),
-              {error, wc, iolist_to_binary(ErrorIoList)}
-            end())
+          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, "hello")),
+          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, <<"hello">>)),
+          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, [<<"hello">>])),
+          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, [<<"he">>, <<"llo">>])),
+          ?_E(ok,                       stdinout:reload(cat1)),
+          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, ["he", "llo"])),
+          ?_E({ok, []},                 stdinout:send(cat1, "")),
+          ?_E(ok,                       stdinout:reload(cat2)),
+          ?_E({ok, [<<"hello">>]},      stdinout:pipe("hello",[cat1, cat2, cat3, cat4])),
+
+          ?_E({error, cat1, [<<"hello">>]},
+                                        stdinout:pipe("hello", [{cat1, "he"}, cat2, cat3, cat4])),
+
+          ?_E({error, wc, [<<"      0       1       5\n">>]},
+                                        stdinout:pipe("hello", [{cat1, "bob"}, {wc, "5"}, cat3, cat4])),
+
+          % Assert that binary responses on stdout can start with status byte 145 or 146
+          ?_E({ok, [<<145,23,88,97>>]},      stdinout:send(cat1, <<145,23,88,97>>)),
+          ?_E({ok, [<<146,23,88,97>>]},      stdinout:send(cat1, <<146,23,88,97>>)),
+          ?_E({ok, [<<146,23,88,97>>]},      stdinout:pipe(<<146,23,88,97>>,[cat1, cat2, cat3, cat4]))
+        ]
+      }
+    end
+  }.
+
+% Test responses on STDERR
+everything_erlang_API_in_parallel_error_test_() ->
+  {setup,
+    fun setup_ports/0,
+    fun cleanup_ports/1,
+    fun(_) ->
+      {inparallel,
+        [
+          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, "hello")),
+          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, <<"hello">>)),
+          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, [<<"hello">>])),
+          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, [<<"he">>, <<"llo">>])),
+          ?_E(ok,                               stdinout:reload(errcat)),
+          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, ["he", "llo"])),
+          ?_E({error, errcat, [<<"hello">>]},   stdinout:pipe("hello",[errcat, cat2, cat3, cat4])),
+          ?_E({error, errcat, [<<"hello">>]},   stdinout:pipe("hello",[cat1, cat2, errcat, cat4])),
+
+          % Assert that binary responses on stderr can start with status byte 145 or 146
+          ?_E({error, [<<145,23,88,97>>]},              stdinout:send(errcat, <<145,23,88,97>>)),
+          ?_E({error, [<<146,23,88,97>>]},              stdinout:send(errcat, <<146,23,88,97>>)),
+          ?_E({error, errcat, [<<146,23,88,97>>]},      stdinout:pipe(<<146,23,88,97>>,[errcat, cat2, cat3, cat4])),
+          ?_E({error, errcat, [<<146,23,88,97>>]},      stdinout:pipe(<<146,23,88,97>>,[cat1, cat2, errcat, cat4]))
         ]
       }
     end
@@ -80,26 +107,50 @@ network_API_test_() ->
     fun(_) ->
       {inparallel,
         [
-          ?_E(<<"hello">>, ?B(stdinout:send(?C1, "hello"))),
-          ?_E(<<"hello">>, ?B(stdinout:send(?C2, <<"hello">>))),
-          ?_E(<<"hello">>, ?B(stdinout:send(?C1, [<<"hello">>]))),
-          ?_E(<<"hello">>, ?B(stdinout:send(?C1, [<<"he">>, <<"llo">>]))),
-          ?_E(<<"hello">>, ?B(stdinout:send(?C2, ["he", "llo"]))),
-          ?_E(<<>>, ?B(stdinout:send(?C1, ""))),
-          ?_E(<<"hello">>, ?B(stdinout:pipe("hello", [?C1, ?C2, ?C1, ?C2]))),
-          ?_E({error, ?C1, <<"hello">>},
-            % this wacky fun exists to erlang:iolist_to_binary/1 the ErrorIoList
-            fun() ->
-              {error, ?C1, ErrorIoList} =
-                stdinout:pipe("hello", [{?C1, "he"}, ?C2, ?C2, ?C1]),
-              {error, ?C1, iolist_to_binary(ErrorIoList)}
-            end()),
-          ?_E({error, ?W1, <<"      0       1       5\n">>},
-            fun() ->
-              {error, ?W1, ErrorIoList} =
-                stdinout:pipe("hello", [{?C2, "bob"}, {?W1, "5"}, ?C2, ?C1]),
-              {error, ?W1, iolist_to_binary(ErrorIoList)}
-            end())
+          ?_E({ok, [<<"hello">>]},      stdinout:send(?C1, "hello")),
+          ?_E({ok, [<<"hello">>]},      stdinout:send(?C2, <<"hello">>)),
+          ?_E({ok, [<<"hello">>]},      stdinout:send(?C1, [<<"hello">>])),
+          ?_E({ok, [<<"hello">>]},      stdinout:send(?C1, [<<"he">>, <<"llo">>])),
+          ?_E({ok, [<<"hello">>]},      stdinout:send(?C2, ["he", "llo"])),
+          ?_E({ok, []},                 stdinout:send(?C1, "")),
+          ?_E({ok, [<<"hello">>]},      stdinout:pipe("hello", [?C1, ?C2, ?C1, ?C2])),
+
+          ?_E({error, ?C1, [<<"hello">>]},
+                                        stdinout:pipe("hello", [{?C1, "he"}, ?C2, ?C2, ?C1])),
+
+          ?_E({error, ?W1, [<<"      0       1       5\n">>]},
+                                        stdinout:pipe("hello", [{?C2, "bob"}, {?W1, "5"}, ?C2, ?C1])),
+
+          % Assert that network binary responses on stdout can start with status byte 145 or 146
+          ?_E({ok, [<<145,23,88,97>>]},      stdinout:send(?C1, <<145,23,88,97>>)),
+          ?_E({ok, [<<146,23,88,97>>]},      stdinout:send(?C2, <<146,23,88,97>>)),
+          ?_E({ok, [<<146,23,88,97>>]},      stdinout:pipe(<<146,23,88,97>>, [?C1, ?C2, ?C1, ?C2]))
+        ]
+      }
+    end
+  }.
+
+-define(E2, {"localhost", 6654}).
+network_API_error_test_() ->
+  {setup,
+    fun setup_ports/0,
+    fun cleanup_ports/1,
+    fun(_) ->
+      {inparallel,
+        [
+          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, "hello")),
+          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, <<"hello">>)),
+          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, [<<"hello">>])),
+          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, [<<"he">>, <<"llo">>])),
+          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, ["he", "llo"])),
+
+          ?_E({error,{"localhost",6654},[<<"hello">>]},
+                                                stdinout:pipe("hello", [?C1, ?C2, ?E2, ?C1])),
+
+          % Assert that network binary responses on stderr can start with status byte 145 or 146
+          ?_E({error, [<<145,23,88,97>>]},                      stdinout:send(errcat, <<145,23,88,97>>)),
+          ?_E({error, [<<146,23,88,97>>]},                      stdinout:send(errcat, <<146,23,88,97>>)),
+          ?_E({error, {"localhost",6654}, [<<146,23,88,97>>]},  stdinout:pipe(<<146,23,88,97>>,[?C1, ?C2, ?E2, ?C1]))
         ]
       }
     end

--- a/test/stdinout_tests.erl
+++ b/test/stdinout_tests.erl
@@ -45,26 +45,26 @@ everything_erlang_API_in_parallel_test_() ->
     fun(_) ->
       {inparallel,
         [
-          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, "hello")),
-          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, <<"hello">>)),
-          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, [<<"hello">>])),
-          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, [<<"he">>, <<"llo">>])),
+          ?_E({ok, <<"hello">>},      stdinout:send(cat1, "hello")),
+          ?_E({ok, <<"hello">>},      stdinout:send(cat1, <<"hello">>)),
+          ?_E({ok, <<"hello">>},      stdinout:send(cat1, [<<"hello">>])),
+          ?_E({ok, <<"hello">>},      stdinout:send(cat1, [<<"he">>, <<"llo">>])),
           ?_E(ok,                       stdinout:reload(cat1)),
-          ?_E({ok, [<<"hello">>]},      stdinout:send(cat1, ["he", "llo"])),
-          ?_E({ok, []},                 stdinout:send(cat1, "")),
+          ?_E({ok, <<"hello">>},      stdinout:send(cat1, ["he", "llo"])),
+          ?_E({ok, <<>>},                 stdinout:send(cat1, "")),
           ?_E(ok,                       stdinout:reload(cat2)),
-          ?_E({ok, [<<"hello">>]},      stdinout:pipe("hello",[cat1, cat2, cat3, cat4])),
+          ?_E({ok, <<"hello">>},      stdinout:pipe("hello",[cat1, cat2, cat3, cat4])),
 
-          ?_E({error, cat1, [<<"hello">>]},
+          ?_E({error, cat1, <<"hello">>},
                                         stdinout:pipe("hello", [{cat1, "he"}, cat2, cat3, cat4])),
 
-          ?_E({error, wc, [<<"      0       1       5\n">>]},
+          ?_E({error, wc, <<"      0       1       5\n">>},
                                         stdinout:pipe("hello", [{cat1, "bob"}, {wc, "5"}, cat3, cat4])),
 
           % Assert that binary responses on stdout can start with status byte 145 or 146
-          ?_E({ok, [<<145,23,88,97>>]},      stdinout:send(cat1, <<145,23,88,97>>)),
-          ?_E({ok, [<<146,23,88,97>>]},      stdinout:send(cat1, <<146,23,88,97>>)),
-          ?_E({ok, [<<146,23,88,97>>]},      stdinout:pipe(<<146,23,88,97>>,[cat1, cat2, cat3, cat4]))
+          ?_E({ok, <<145,23,88,97>>},      stdinout:send(cat1, <<145,23,88,97>>)),
+          ?_E({ok, <<146,23,88,97>>},      stdinout:send(cat1, <<146,23,88,97>>)),
+          ?_E({ok, <<146,23,88,97>>},      stdinout:pipe(<<146,23,88,97>>,[cat1, cat2, cat3, cat4]))
         ]
       }
     end
@@ -78,20 +78,20 @@ everything_erlang_API_in_parallel_error_test_() ->
     fun(_) ->
       {inparallel,
         [
-          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, "hello")),
-          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, <<"hello">>)),
-          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, [<<"hello">>])),
-          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, [<<"he">>, <<"llo">>])),
+          ?_E({error, <<"hello">>},           stdinout:send(errcat, "hello")),
+          ?_E({error, <<"hello">>},           stdinout:send(errcat, <<"hello">>)),
+          ?_E({error, <<"hello">>},           stdinout:send(errcat, [<<"hello">>])),
+          ?_E({error, <<"hello">>},           stdinout:send(errcat, [<<"he">>, <<"llo">>])),
           ?_E(ok,                               stdinout:reload(errcat)),
-          ?_E({error, [<<"hello">>]},           stdinout:send(errcat, ["he", "llo"])),
-          ?_E({error, errcat, [<<"hello">>]},   stdinout:pipe("hello",[errcat, cat2, cat3, cat4])),
-          ?_E({error, errcat, [<<"hello">>]},   stdinout:pipe("hello",[cat1, cat2, errcat, cat4])),
+          ?_E({error, <<"hello">>},           stdinout:send(errcat, ["he", "llo"])),
+          ?_E({error, errcat, <<"hello">>},   stdinout:pipe("hello",[errcat, cat2, cat3, cat4])),
+          ?_E({error, errcat, <<"hello">>},   stdinout:pipe("hello",[cat1, cat2, errcat, cat4])),
 
           % Assert that binary responses on stderr can start with status byte 145 or 146
-          ?_E({error, [<<145,23,88,97>>]},              stdinout:send(errcat, <<145,23,88,97>>)),
-          ?_E({error, [<<146,23,88,97>>]},              stdinout:send(errcat, <<146,23,88,97>>)),
-          ?_E({error, errcat, [<<146,23,88,97>>]},      stdinout:pipe(<<146,23,88,97>>,[errcat, cat2, cat3, cat4])),
-          ?_E({error, errcat, [<<146,23,88,97>>]},      stdinout:pipe(<<146,23,88,97>>,[cat1, cat2, errcat, cat4]))
+          ?_E({error, <<145,23,88,97>>},              stdinout:send(errcat, <<145,23,88,97>>)),
+          ?_E({error, <<146,23,88,97>>},              stdinout:send(errcat, <<146,23,88,97>>)),
+          ?_E({error, errcat, <<146,23,88,97>>},      stdinout:pipe(<<146,23,88,97>>,[errcat, cat2, cat3, cat4])),
+          ?_E({error, errcat, <<146,23,88,97>>},      stdinout:pipe(<<146,23,88,97>>,[cat1, cat2, errcat, cat4]))
         ]
       }
     end
@@ -107,24 +107,24 @@ network_API_test_() ->
     fun(_) ->
       {inparallel,
         [
-          ?_E({ok, [<<"hello">>]},      stdinout:send(?C1, "hello")),
-          ?_E({ok, [<<"hello">>]},      stdinout:send(?C2, <<"hello">>)),
-          ?_E({ok, [<<"hello">>]},      stdinout:send(?C1, [<<"hello">>])),
-          ?_E({ok, [<<"hello">>]},      stdinout:send(?C1, [<<"he">>, <<"llo">>])),
-          ?_E({ok, [<<"hello">>]},      stdinout:send(?C2, ["he", "llo"])),
-          ?_E({ok, []},                 stdinout:send(?C1, "")),
-          ?_E({ok, [<<"hello">>]},      stdinout:pipe("hello", [?C1, ?C2, ?C1, ?C2])),
+          ?_E({ok, <<"hello">>},      stdinout:send(?C1, "hello")),
+          ?_E({ok, <<"hello">>},      stdinout:send(?C2, <<"hello">>)),
+          ?_E({ok, <<"hello">>},      stdinout:send(?C1, [<<"hello">>])),
+          ?_E({ok, <<"hello">>},      stdinout:send(?C1, [<<"he">>, <<"llo">>])),
+          ?_E({ok, <<"hello">>},      stdinout:send(?C2, ["he", "llo"])),
+          ?_E({ok, <<>>},                 stdinout:send(?C1, "")),
+          ?_E({ok, <<"hello">>},      stdinout:pipe("hello", [?C1, ?C2, ?C1, ?C2])),
 
-          ?_E({error, ?C1, [<<"hello">>]},
+          ?_E({error, ?C1, <<"hello">>},
                                         stdinout:pipe("hello", [{?C1, "he"}, ?C2, ?C2, ?C1])),
 
-          ?_E({error, ?W1, [<<"      0       1       5\n">>]},
+          ?_E({error, ?W1, <<"      0       1       5\n">>},
                                         stdinout:pipe("hello", [{?C2, "bob"}, {?W1, "5"}, ?C2, ?C1])),
 
           % Assert that network binary responses on stdout can start with status byte 145 or 146
-          ?_E({ok, [<<145,23,88,97>>]},      stdinout:send(?C1, <<145,23,88,97>>)),
-          ?_E({ok, [<<146,23,88,97>>]},      stdinout:send(?C2, <<146,23,88,97>>)),
-          ?_E({ok, [<<146,23,88,97>>]},      stdinout:pipe(<<146,23,88,97>>, [?C1, ?C2, ?C1, ?C2]))
+          ?_E({ok, <<145,23,88,97>>},      stdinout:send(?C1, <<145,23,88,97>>)),
+          ?_E({ok, <<146,23,88,97>>},      stdinout:send(?C2, <<146,23,88,97>>)),
+          ?_E({ok, <<146,23,88,97>>},      stdinout:pipe(<<146,23,88,97>>, [?C1, ?C2, ?C1, ?C2]))
         ]
       }
     end
@@ -138,19 +138,19 @@ network_API_error_test_() ->
     fun(_) ->
       {inparallel,
         [
-          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, "hello")),
-          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, <<"hello">>)),
-          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, [<<"hello">>])),
-          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, [<<"he">>, <<"llo">>])),
-          ?_E({error, [<<"hello">>]},           stdinout:send(?E2, ["he", "llo"])),
+          ?_E({error, <<"hello">>},           stdinout:send(?E2, "hello")),
+          ?_E({error, <<"hello">>},           stdinout:send(?E2, <<"hello">>)),
+          ?_E({error, <<"hello">>},           stdinout:send(?E2, [<<"hello">>])),
+          ?_E({error, <<"hello">>},           stdinout:send(?E2, [<<"he">>, <<"llo">>])),
+          ?_E({error, <<"hello">>},           stdinout:send(?E2, ["he", "llo"])),
 
-          ?_E({error,{"localhost",6654},[<<"hello">>]},
+          ?_E({error,{"localhost",6654},<<"hello">>},
                                                 stdinout:pipe("hello", [?C1, ?C2, ?E2, ?C1])),
 
           % Assert that network binary responses on stderr can start with status byte 145 or 146
-          ?_E({error, [<<145,23,88,97>>]},                      stdinout:send(errcat, <<145,23,88,97>>)),
-          ?_E({error, [<<146,23,88,97>>]},                      stdinout:send(errcat, <<146,23,88,97>>)),
-          ?_E({error, {"localhost",6654}, [<<146,23,88,97>>]},  stdinout:pipe(<<146,23,88,97>>,[?C1, ?C2, ?E2, ?C1]))
+          ?_E({error, <<145,23,88,97>>},                      stdinout:send(errcat, <<145,23,88,97>>)),
+          ?_E({error, <<146,23,88,97>>},                      stdinout:send(errcat, <<146,23,88,97>>)),
+          ?_E({error, {"localhost",6654}, <<146,23,88,97>>},  stdinout:pipe(<<146,23,88,97>>,[?C1, ?C2, ?E2, ?C1]))
         ]
       }
     end


### PR DESCRIPTION
Fixes issue #10 
Pipes will now exit on error instead of piping the error output to the next process in the pipe.

Also improved readability of unit tests.
Check the unit tests to see the implications of these changes.

I hope you like these changes.